### PR TITLE
Fix ArgumentException in when send GET requests in Unity 2021.1

### DIFF
--- a/Facebook.Unity/Results/GraphResult.cs
+++ b/Facebook.Unity/Results/GraphResult.cs
@@ -22,20 +22,25 @@ namespace Facebook.Unity
 {
     using System.Collections.Generic;
     using UnityEngine;
+    using UnityEngine.Networking;
 
     internal class GraphResult : ResultBase, IGraphResult
-    {
-        internal GraphResult(WWW result) : base(new ResultContainer(result.text), result.error, false)
+    {       
+        internal GraphResult(UnityWebRequestAsyncOperation result) :
+            base(new ResultContainer(result.webRequest.downloadHandler.text), result.webRequest.error, false)
         {
+            
             this.Init(this.RawResult);
 
             // The WWW object will throw an exception if accessing the texture field and
             // an error has occured.
-            if (result.error == null)
+            if (string.IsNullOrEmpty(result.webRequest.error))
             {
                 // The Graph API does not return textures directly, but a few endpoints can
                 // redirect to images when no 'redirect=false' parameter is specified. Ex: '/me/picture'
-                this.Texture = result.texture;
+                
+                this.Texture = new Texture2D(2, 2);
+                this.Texture.LoadImage(result.webRequest.downloadHandler.data);
             }
         }
 

--- a/Facebook.Unity/Utils/AsyncRequestString.cs
+++ b/Facebook.Unity/Utils/AsyncRequestString.cs
@@ -24,6 +24,7 @@ namespace Facebook.Unity
     using System.Collections;
     using System.Collections.Generic;
     using UnityEngine;
+    using UnityEngine.Networking;
 
     /*
      * A short lived async request that loads a FBResult from a url endpoint
@@ -80,7 +81,7 @@ namespace Facebook.Unity
 
         internal IEnumerator Start()
         {
-            WWW www;
+            UnityWebRequestAsyncOperation webRequestOperation;
             if (this.method == HttpMethod.GET)
             {
                 string urlParams = this.url.AbsoluteUri.Contains("?") ? "&" : "?";
@@ -92,14 +93,13 @@ namespace Facebook.Unity
                     }
                 }
 
-                Dictionary<string, string> headers = new Dictionary<string, string>();
-
+                UnityWebRequest webRequest = UnityWebRequest.Get(url + urlParams);
                 if (Constants.CurrentPlatform != FacebookUnityPlatform.WebGL)
                 {
-                    headers["User-Agent"] = Constants.GraphApiUserAgent;
+                    webRequest.SetRequestHeader("User-Agent", Constants.GraphApiUserAgent);
                 }
 
-                www = new WWW(this.url + urlParams, null, headers);
+                webRequestOperation = webRequest.SendWebRequest();
             }
             else
             {
@@ -127,18 +127,19 @@ namespace Facebook.Unity
                     this.query.headers["User-Agent"] = Constants.GraphApiUserAgent;
                 }
 
-                www = new WWW(this.url.AbsoluteUri, this.query);
+                UnityWebRequest webRequest = UnityWebRequest.Post(url.AbsoluteUri, query);
+                webRequestOperation = webRequest.SendWebRequest();
             }
 
-            yield return www;
+            yield return webRequestOperation;
 
             if (this.callback != null)
             {
-                this.callback(new GraphResult(www));
+                this.callback(new GraphResult(webRequestOperation));
             }
 
-            // after the callback is called, www should be able to be disposed
-            www.Dispose();
+            // after the callback is called, web request should be able to be disposed
+            webRequestOperation.webRequest.Dispose();
             MonoBehaviour.Destroy(this);
         }
 


### PR DESCRIPTION
WWW class doesn't check whether postData is null when it creates UploadHandler. This is bug in Unity 2021.1.0f1.
Anyway WWW is an obsolete class and may be removed in future versions of Unity.
